### PR TITLE
Fix source url for letmecreate and pyletmecreate packages.

### DIFF
--- a/letmecreate/Makefile
+++ b/letmecreate/Makefile
@@ -5,7 +5,7 @@ PKG_VERSION:=1.0.2
 
 PKG_SOURCE_VERSION:=HEAD
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
-PKG_SOURCE_URL:= git@github.com:francois-berder/LetMeCreate.git
+PKG_SOURCE_URL:=https://github.com/francois-berder/LetMeCreate.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 

--- a/pyletmecreate/Makefile
+++ b/pyletmecreate/Makefile
@@ -5,7 +5,7 @@ PKG_VERSION:=1.0.2
 
 PKG_SOURCE_VERSION:=HEAD
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
-PKG_SOURCE_URL:= git@github.com:francois-berder/PyLetMeCreate.git
+PKG_SOURCE_URL:=https://github.com/francois-berder/PyLetMeCreate.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 


### PR DESCRIPTION
Changed  PKG_SOURCE_URL to https.
So that any user can download without adding his public key to git repo.

Signed-off-by: jai-bits jaishiv5@gmail.com
