### PR TITLE
Add initial Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,15 @@
+#!/usr/bin/env groovy
+
+properties([
+    parameters([
+        string(defaultValue: 'ci40', description: 'OpenWrt branch to test against', \
+            name: "OPENWRT_BRANCH")
+    ])
+])
+
+stage('Trigger openwrt build') {
+    build job: "../openwrt/${OPENWRT_BRANCH}", parameters: [
+        string(name: 'OVERRIDE_CREATOR-FEED', value: "${BRANCH_NAME}")
+    ]
+}
+


### PR DESCRIPTION
Simply trigger the openwrt job to override this feed and wait for its results.

Signed-off-by: Nikhil Zinjurde <nikhil.zinjurde@imgtec.com>