### PR TITLE
Jenkinsfile: continue building packages despite failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,12 @@ node('docker && imgtec') {
                         throw err
                     }
                     echo 'Parallel build failed, attempting to continue in single threaded mode'
-                    sh "make package/${item}/compile -j1 V=s"
+                    try {
+                        sh "make package/${item}/compile -j1 V=s"
+                    } catch (exc) {
+                        echo "Caught: ${exc}"
+                        currentBuild.result = 'FAILURE'
+                    }
                 }
             }
             // Add package signing key


### PR DESCRIPTION
Do not stop CI when package(s) fail(s) to build. Fail CI once building all packages finishes

This fixes #40 

Signed-off-by: Nikhil Zinjurde <nikhil.zinjurde@imgtec.com>